### PR TITLE
Add Jest tests for tokenize()

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  transform: {},
+};

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "mocha": "^11.0.1"
+    "jest": "^29.7.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "type": "module"
 }

--- a/sgf/parse-sgf.test.js
+++ b/sgf/parse-sgf.test.js
@@ -1,0 +1,39 @@
+import { tokenize } from './parse-sgf';
+
+describe('tokenize function', () => {
+  test('should tokenize a simple SGF string with a single property', async () => {
+    const sgf = '(;FF[4])';
+    const expectedTokens = [
+      { type: 'terminal', value: '(' },
+      { type: 'terminal', value: ';' },
+      { type: 'propId', value: 'FF' },
+      { type: 'propVal', value: '4' },
+      { type: 'terminal', value: ')' },
+    ];
+    await expect(tokenize(sgf)).resolves.toEqual(expectedTokens);
+  });
+
+  test('should handle escaped characters within property values', async () => {
+    const sgf = String.raw`(;C[This is a comment with an escaped newline\
+and a colon\:])`;
+    const expectedTokens = [
+      { type: 'terminal', value: '(' },
+      { type: 'terminal', value: ';' },
+      { type: 'propId', value: 'C' },
+      { type: 'propVal', value: 'This is a comment with an escaped newlineand a colon<ESCAPEDCOLON>' },
+      { type: 'terminal', value: ')' },
+    ];
+    await expect(tokenize(sgf)).resolves.toEqual(expectedTokens);
+  });
+
+  test('should throw an error for missing closing bracket', async () => {
+    const sgf = '(;C[Missing closing bracket)';
+    await expect(tokenize(sgf)).rejects.toThrow("missing ']'");
+  });
+
+  test('should throw an error for property ID without value', async () => {
+    const sgf = '(;FF)';
+    await expect(tokenize(sgf)).rejects.toThrow('expecting propVal after propId');
+  });
+});
+

--- a/sgf/sgf.js
+++ b/sgf/sgf.js
@@ -3,13 +3,13 @@
  */
 import { tokenize, parseTokens, buildGameObject } from "./parse-sgf.js";
 import { sgfPropOrder, propertyDefinitions } from "./sgfProperties.js";
+import { COORDINATES, numCoord } from "./sgfUtils.js";
 const propOrder = sgfPropOrder.flat();
 const blackInfo = ['PB','BR','BT'];
 const whiteInfo = ['PW','WR','WT'];
 const timeInfo = ['TM','OT'];
 
 class SGF {
-    static coordinates = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
     static zippableProperties = [
         'AB',
         'AE',
@@ -32,21 +32,12 @@ class SGF {
     ]
 
     /**
-     * Converts single SGF coordinate string into single numeric coordinate
-     * @param {string} sgfCoord Alpha SGF coordinate string
-     * @returns {number[]} Numeric coordinate
-     */
-    static numCoord(sgfCoord) {
-        return Array.from(sgfCoord).map(char => SGF.coordinates.indexOf(char));
-    }
-
-    /**
      * Unzips 'ab:bc' coords into array [[0,1],[1,1],[0,2],[2,2]]
      * @param {string} zipped Compressed SGF coordinates 'wx:yz'
      * @returns {string[]} Array of uncompressed SGF coordinates [n,n]
      */
     static unzipCoords(zipped) {
-        let coords = zipped.split(':').map(coord => SGF.numCoord(coord));
+        let coords = zipped.split(':').map(coord => numCoord(coord));
         let unzipped = [];
 
         for (let x = coords[0][0]; x <= coords[1][0]; x++) {
@@ -105,7 +96,7 @@ class SGF {
                     if (typeof val !== 'string') {
                         newVal = '';
                         for (let number of val) {
-                            newVal += SGF.coordinates[number];
+                            newVal += COORDINATES[number];
                         }
                     } 
                     values.push(newVal.replaceAll('\\','\\\\').replaceAll(']','\\]'));

--- a/sgf/sgfProperties.js
+++ b/sgf/sgfProperties.js
@@ -1,4 +1,4 @@
-import SGF from "./sgf.js";
+import { numCoord } from "./sgfUtils.js";
 
 /**
  * Returns a parsed number if it is in the expected range, or throws and error
@@ -95,7 +95,7 @@ const move = (propVal, propIdent) => {
     // this also only allows only one move per turn, 
     // and doesn't allow empty propvals for passing
     if (/[A-Za-z]/.test(propVal) && propVal.length === 2) {
-        return SGF.numCoord(propVal);
+        return numCoord(propVal);
     }
     throw new Error(`${propIdent}[${propVal}] is not allowed`);
 }

--- a/sgf/sgfUtils.js
+++ b/sgf/sgfUtils.js
@@ -1,0 +1,12 @@
+const COORDINATES = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+/**
+ * Converts single SGF coordinate string into single numeric coordinate
+ * @param {string} sgfCoord Alpha SGF coordinate string
+ * @returns {number[]} Numeric coordinate
+ */
+function numCoord(sgfCoord) {
+    return Array.from(sgfCoord).map(char => COORDINATES.indexOf(char));
+}
+
+export {COORDINATES, numCoord}; 

--- a/sgf/sgfUtils.test.js
+++ b/sgf/sgfUtils.test.js
@@ -1,0 +1,7 @@
+import { numCoord } from "./sgfUtils.js"
+
+test("numCoord", () => {
+    expect(numCoord("aa")).toEqual([0, 0]);
+    expect(numCoord("AA")).toEqual([26, 26]);
+    expect(numCoord("tt")).toEqual([19, 19]);
+});


### PR DESCRIPTION
This PR is intended to show how Jest can be used for this repo.   I chose to test `tokenize` because it is the first step in the pipeline.

You can run these tests with `npm test`, or if you are interested to see the [coverage report](https://jestjs.io/docs/cli#--coverageboolean), `npm test -- --coverage`.

```
$ npm test

> test
> node --experimental-vm-modules node_modules/jest/bin/jest.js

(node:15573) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  sgf/parse-sgf.test.js
 PASS  sgf/sgfUtils.test.js

Test Suites: 2 passed, 2 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        0.55 s, estimated 1 s
Ran all test suites.
```

I hit a couple hurdles, will add PR comments to try and explain what I've done.